### PR TITLE
Add leading / to checkup link to format into URI

### DIFF
--- a/_site/in/index.html
+++ b/_site/in/index.html
@@ -34,7 +34,7 @@
             </div>
             <img src="assets/images/arrow.svg" class="arrow action-icon" />
         </a>-->
-        <a class="action" href="sourcegraph/checkup/fs.go?master">
+        <a class="action" href="/sourcegraph/checkup/fs.go?master">
             <div class="action-content">
                 <div class="action-title">Code intelligence </div>
                 <div class="action-description">Jump to a GitHub repository to see how it works.</div>


### PR DESCRIPTION
Adding a leading slash will cause VSCode to automatically convert `/sourcegraph/checkup/fs.go?master` into `repo://sourcegraph/checkup/fs.go?master` so we can jump to the workspace.